### PR TITLE
bugfix - fix cache-miss for user->cachedRoles().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+### 1.9.5
+
+- Fix constant cache miss issue for `user->cachedRoles()`.
+
+  The Traits rely on `App::config('cache.ttl')` and they were missing a default value (equivalent to null) resulting in no caching behaviour.
+  _Oddly the chosen config 'cache.ttl' does not exist by default in Laravel._
+
+  - Move the caching ttl config into the package's config space under 'entrust.cache.ttl'.
+  - Keep the default behaviour as no-caching (null ttl) with expectation the developer will "opt in" to enable caching.
+
 ### 1.9.4
 
 - Do not generate partial cache-keys when a User's primary-key is empty

--- a/README.md
+++ b/README.md
@@ -136,7 +136,28 @@ to `routeMiddleware` array in `app/Http/Kernel.php`.
 Set the property values in the `config/auth.php`.
 These values will be used by entrust to refer to the correct user table and model.
 
-To further customize table names and model namespaces, edit the `config/entrust.php`.
+To further customize table names, model namespaces and __Cache__ behaviour, edit the `config/entrust.php`.
+
+Ensure the configuration is installed/published into your app.
+```
+php artisan vendor:publish --force --provider='Zizaco\Entrust\EntrustServiceProvider' 
+```
+
+### Cache
+
+The package supports caching **Users' Roles** and **Roles' Permissions**.
+
+
+To enable caching change the entrust config **cache.ttl** value, this is the _time to live_ for cache entries in minutes.
+The default ttl value is `null` which disables caching behaviour.
+
+```
+    // config/entrust.php
+    
+    'cache' => [
+        'ttl' => 60
+    ], 
+```
 
 ### User relation to roles
 

--- a/src/Entrust/Traits/EntrustRoleTrait.php
+++ b/src/Entrust/Traits/EntrustRoleTrait.php
@@ -20,7 +20,7 @@ trait EntrustRoleTrait
         $rolePrimaryKey = $this->primaryKey;
         $cacheKey = 'entrust_permissions_for_role_' . $this->$rolePrimaryKey;
         if (Cache::getStore() instanceof TaggableStore) {
-            return Cache::tags(Config::get('entrust.permission_role_table'))->remember($cacheKey, Config::get('cache.ttl', 60), function () {
+            return Cache::tags(Config::get('entrust.permission_role_table'))->remember($cacheKey, Config::get('entrust.cache.ttl'), function () {
                 return $this->perms()->get();
             });
         } else return $this->perms()->get();

--- a/src/Entrust/Traits/EntrustUserTrait.php
+++ b/src/Entrust/Traits/EntrustUserTrait.php
@@ -30,7 +30,7 @@ trait EntrustUserTrait
         }
         $cacheKey = 'entrust_roles_for_user_'.$this->getKey();
         if(Cache::getStore() instanceof TaggableStore) {
-            return Cache::tags(Config::get('entrust.role_user_table'))->remember($cacheKey, Config::get('cache.ttl'), function () {
+            return Cache::tags(Config::get('entrust.role_user_table'))->remember($cacheKey, Config::get('entrust.cache.ttl'), function () {
                 return $this->roles()->get();
             });
         }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -12,6 +12,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Entrust Cache TimeToLive
+    |--------------------------------------------------------------------------
+    |
+    | This is the time to live for cache entries in minutes.
+    | It is applicable to user->cachedRoles() and role->cachedPermissions()
+    |
+    | A null value disables caching.
+    |
+    */
+    'cache' => [
+        'ttl' => null
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Entrust Role Model
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
The Traits rely on App::config('cache.ttl') and they were missing a default value (equivalent to null) resulting in no caching behaviour.
_Oddly the chosen config 'cache.ttl' does not exist by default in Laravel._

Move the caching ttl config into the package's config space under 'entrust.cache.ttl' and keep default no-caching (null ttl) behaviour with expectation of "opt into" caching
